### PR TITLE
Updated deployment automation to handle the new EFM

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,6 +16,15 @@ jobs:
               with:
                 path: f-22a
                 lfs: true
+                submodules: 'recursive'
+
+            - name: Configure CMake
+              working-directory: f-22a
+              run: cmake --preset x64-release -G "Visual Studio 17 2022"
+
+            - name: Build EFM
+              working-directory: f-22a
+              run: cmake --build --preset x64-release
 
             - name: Clean Project
               working-directory: f-22a
@@ -27,6 +36,11 @@ jobs:
                 Remove-Item -Path .gitattributes -Force -ErrorAction SilentlyContinue
                 Remove-Item -Path README.md -Force -ErrorAction SilentlyContinue
                 Remove-Item -Path CONTRIBUTING.md -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path EFM - Force -ErrorAction SilentlyContinue
+                Remove-Item -Path *.pdb -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path CMakePresets.json -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path CMakeLists.txt -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path out -Force -ErrorAction SilentlyContinue
 
             - name: Compress Files
               run: Compress-Archive -Path f-22a -DestinationPath f-22a.zip


### PR DESCRIPTION
Added automated deployments to work with the new EFM code.

@JGrinnelli please check the deployment lines 39-43 to make sure we're deleting all the new files. Should currently be deleting generated debug symbols, EFM folder, CMakeLists & CMakePresets, and build folder. Anything else that needs to be deleted?